### PR TITLE
adding getters for buffers

### DIFF
--- a/src/MPU9250_asukiaaa.cpp
+++ b/src/MPU9250_asukiaaa.cpp
@@ -147,6 +147,9 @@ float MPU9250_asukiaaa::magY() {
 float MPU9250_asukiaaa::magZ() {
   return adjustMagValue(magGet(5, 4), magZAdjust) + magZOffset;
 }
+uint8_t* MPU9250_asukiaaa::getMagBuffer() {
+  return magBuf;
+}
 
 uint8_t MPU9250_asukiaaa::accelUpdate() {
   return i2cRead(address, MPU9250_ADDR_ACCEL_XOUT_H, 6, accelBuf);
@@ -173,6 +176,9 @@ float MPU9250_asukiaaa::accelSqrt() {
   return sqrt(pow(accelGet(0, 1), 2) +
               pow(accelGet(2, 3), 2) +
               pow(accelGet(4, 5), 2));
+}
+uint8_t* MPU9250_asukiaaa::getAccelBuffer() {
+  return accelBuf;
 }
 
 void MPU9250_asukiaaa::beginGyro(uint8_t mode) {
@@ -216,4 +222,7 @@ float MPU9250_asukiaaa::gyroY() {
 
 float MPU9250_asukiaaa::gyroZ() {
   return gyroGet(4, 5);
+}
+uint8_t* MPU9250_asukiaaa::getGyroBuffer() {
+  return gyroBuf;
 }

--- a/src/MPU9250_asukiaaa.h
+++ b/src/MPU9250_asukiaaa.h
@@ -46,12 +46,14 @@ class MPU9250_asukiaaa {
   float accelY();
   float accelZ();
   float accelSqrt();
+  uint8_t* getAccelBuffer();
 
   void beginGyro(uint8_t mode = GYRO_FULL_SCALE_2000_DPS);
   uint8_t gyroUpdate();
   float gyroX();
   float gyroY();
   float gyroZ();
+  uint8_t* getGyroBuffer();
 
   void beginMag(uint8_t mode = MAG_MODE_CONTINUOUS_8HZ);
   void magSetMode(uint8_t mode);
@@ -60,6 +62,7 @@ class MPU9250_asukiaaa {
   float magY();
   float magZ();
   float magHorizDirection();
+  uint8_t* getMagBuffer();
 
   private:
   TwoWire* myWire;


### PR DESCRIPTION
Adding getters for buffers so we can have access to data in uint8 instead of Float because it is more easy to use for wireless transmission. BLE and Wifi send data as uint8 buffers so this commit avoid recasting of float into uint8.