### PR TITLE
Fix for readId

### DIFF
--- a/src/MPU9250_asukiaaa.cpp
+++ b/src/MPU9250_asukiaaa.cpp
@@ -54,6 +54,7 @@ void MPU9250_asukiaaa::setWire(TwoWire* wire) {
 }
 
 uint8_t MPU9250_asukiaaa::readId(uint8_t *id) {
+   beginWireIfNull();
   return i2cRead(address, MPU9250_ADDR_WHOAMI, 1, id);
 }
 


### PR DESCRIPTION
adding  beginWireIfNull(); in readId so we can check if sensor is working before starting sensor
Before this fix the readId return something only when it is called after mySensor.beginAcc() , mySensor.beginGyro();  or mySensor.beginMag();